### PR TITLE
Integration of Terramodtest 0.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull the base image with given version.
-ARG BUILD_TERRAFORM_VERSION="0.13.0"
+ARG BUILD_TERRAFORM_VERSION="0.13.5"
 FROM mcr.microsoft.com/terraform-test:${BUILD_TERRAFORM_VERSION}
 
 ARG MODULE_NAME="terraform-azurerm-postgresql"
@@ -31,6 +31,7 @@ WORKDIR /go/src/${MODULE_NAME}
 # Install dep.
 ENV GOPATH /go
 ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH
+RUN go get github.com/katbyte/terrafmt
 RUN /bin/bash -c "curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh"
 
 RUN ["bundle", "install", "--gemfile", "./Gemfile"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org/'
 
 group :test do
   git 'https://github.com/Azure/terramodtest.git' do
-    gem 'terramodtest', :tag => 'v0.7.0'
+    gem 'terramodtest', :tag => 'v0.8.0'
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,12 @@ namespace :static do
   task :format do
     format_tf
   end
+  task :readme_style do
+    readme_style_tf
+  end
+  task :fixture_style do
+    fixture_style_tf
+  end
 end
 
 namespace :integration do
@@ -35,7 +41,7 @@ end
 
 task :prereqs => []
 
-task :validate => [ 'static:style', 'static:lint' ]
+task :validate => [ 'static:style', 'static:lint', 'static:readme_style','static:fixture_style' ]
 
 task :format => [ 'static:format' ]
 


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-postgresql .
$ docker run --rm azure-postgresql /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:
Integration of Terramodtest 0.8.0

