### PR TITLE
Add public_network_access_enabled variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,19 @@ module "postgresql" {
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
 
-  server_name                  = "example-server"
-  sku_name                     = "GP_Gen5_2"
-  storage_mb                   = 5120
-  backup_retention_days        = 7
-  geo_redundant_backup_enabled = false
-  administrator_login          = "login"
-  administrator_password       = "password"
-  server_version               = "9.5"
-  ssl_enforcement_enabled      = true
-  db_names                     = ["my_db1", "my_db2"]
-  db_charset                   = "UTF8"
-  db_collation                 = "English_United States.1252"
+  server_name                   = "example-server"
+  sku_name                      = "GP_Gen5_2"
+  storage_mb                    = 5120
+  backup_retention_days         = 7
+  geo_redundant_backup_enabled  = false
+  administrator_login           = "login"
+  administrator_password        = "password"
+  server_version                = "9.5"
+  ssl_enforcement_enabled       = true
+  public_network_access_enabled = true
+  db_names                      = ["my_db1", "my_db2"]
+  db_charset                    = "UTF8"
+  db_collation                  = "English_United States.1252"
 
   firewall_rule_prefix = "firewall-"
   firewall_rules = [
@@ -76,18 +77,19 @@ module "postgresql" {
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
 
-  server_name                  = "example-server"
-  sku_name                     = "GP_Gen5_2"
-  storage_mb                   = 5120
-  backup_retention_days        = 7
-  geo_redundant_backup_enabled = false
-  administrator_login          = "login"
-  administrator_password       = "password"
-  server_version               = "9.5"
-  ssl_enforcement_enabled      = true
-  db_names                     = ["my_db1", "my_db2"]
-  db_charset                   = "UTF8"
-  db_collation                 = "English_United States.1252"
+  server_name                   = "example-server"
+  sku_name                      = "GP_Gen5_2"
+  storage_mb                    = 5120
+  backup_retention_days         = 7
+  geo_redundant_backup_enabled  = false
+  administrator_login           = "login"
+  administrator_password        = "password"
+  server_version                = "9.5"
+  ssl_enforcement_enabled       = true
+  public_network_access_enabled = true
+  db_names                      = ["my_db1", "my_db2"]
+  db_charset                    = "UTF8"
+  db_collation                  = "English_United States.1252"
 
   firewall_rule_prefix = "firewall-"
   firewall_rules = [

--- a/main.tf
+++ b/main.tf
@@ -5,14 +5,15 @@ resource "azurerm_postgresql_server" "server" {
 
   sku_name = var.sku_name
 
-  storage_mb                   = var.storage_mb
-  backup_retention_days        = var.backup_retention_days
-  geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
+  storage_mb                    = var.storage_mb
+  backup_retention_days         = var.backup_retention_days
+  geo_redundant_backup_enabled  = var.geo_redundant_backup_enabled
 
-  administrator_login          = var.administrator_login
-  administrator_login_password = var.administrator_password
-  version                      = var.server_version
-  ssl_enforcement_enabled      = var.ssl_enforcement_enabled
+  administrator_login           = var.administrator_login
+  administrator_login_password  = var.administrator_password
+  version                       = var.server_version
+  ssl_enforcement_enabled       = var.ssl_enforcement_enabled
+  public_network_access_enabled = var.public_network_access_enabled
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -5,9 +5,9 @@ resource "azurerm_postgresql_server" "server" {
 
   sku_name = var.sku_name
 
-  storage_mb                    = var.storage_mb
-  backup_retention_days         = var.backup_retention_days
-  geo_redundant_backup_enabled  = var.geo_redundant_backup_enabled
+  storage_mb                   = var.storage_mb
+  backup_retention_days        = var.backup_retention_days
+  geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
 
   administrator_login           = var.administrator_login
   administrator_login_password  = var.administrator_password

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -39,16 +39,17 @@ module "postgresql" {
   server_name = "postgresql${random_id.name.hex}"
   sku_name    = "GP_Gen5_2"
 
-  storage_mb                   = 5120
-  backup_retention_days        = 7
-  geo_redundant_backup_enabled = false
-  administrator_login          = "azureuser"
-  administrator_password       = "Azur3us3r!"
-  server_version               = "9.5"
-  ssl_enforcement_enabled      = true
-  db_names                     = var.db_names
-  db_charset                   = "UTF8"
-  db_collation                 = "English_United States.1252"
+  storage_mb                    = 5120
+  backup_retention_days         = 7
+  geo_redundant_backup_enabled  = false
+  administrator_login           = "azureuser"
+  administrator_password        = "Azur3us3r!"
+  server_version                = "9.5"
+  ssl_enforcement_enabled       = true
+  db_names                      = var.db_names
+  db_charset                    = "UTF8"
+  db_collation                  = "English_United States.1252"
+  public_network_access_enabled = true
 
   firewall_rule_prefix = var.fw_rule_prefix
   firewall_rules       = var.fw_rules

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,12 @@ variable "ssl_enforcement_enabled" {
   default     = true
 }
 
+variable "public_network_access_enabled" {
+  description = "Whether or not public network access is allowed for this server. Possible values are Enabled and Disabled."
+  type        = bool
+  default     = true
+}
+
 variable "db_names" {
   description = "The list of names of the PostgreSQL Database, which needs to be a valid PostgreSQL identifier. Changing this forces a new resource to be created."
   type        = list(string)


### PR DESCRIPTION
Fixes #000 

Changes proposed in the pull request:

* Add public_network_access_enabled variable

Last year this option was added to the azurerm_postgresql_server resource in the azurerm provider, it would be nice if this option could be used in this module. More information: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_server#public_network_access_enabled

I've formatted and tested the change.