### PR TITLE
Replace count with toset

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_postgresql_server" "server" {
 
 resource "azurerm_postgresql_database" "dbs" {
   for_each            = toset(var.db_names)
-  name                = var.db_names[each.key]
+  name                = each.value
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
   charset             = var.db_charset
@@ -28,28 +28,28 @@ resource "azurerm_postgresql_database" "dbs" {
 }
 
 resource "azurerm_postgresql_firewall_rule" "firewall_rules" {
-  for_each            = toset(var.firewall_rules)
-  name                = format("%s%s", var.firewall_rule_prefix, lookup(var.firewall_rules[each.key], "name", each.key))
+  count               = length(var.firewall_rules)
+  name                = format("%s%s", var.firewall_rule_prefix, lookup(var.firewall_rules[count.index], "name", count.index))
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
-  start_ip_address    = var.firewall_rules[each.key]["start_ip"]
-  end_ip_address      = var.firewall_rules[each.key]["end_ip"]
+  start_ip_address    = var.firewall_rules[count.index]["start_ip"]
+  end_ip_address      = var.firewall_rules[count.index]["end_ip"]
 }
 
 resource "azurerm_postgresql_virtual_network_rule" "vnet_rules" {
-  for_each            = toset(var.vnet_rules)
-  name                = format("%s%s", var.vnet_rule_name_prefix, lookup(var.vnet_rules[each.key], "name", each.key))
+  count               = length(var.vnet_rules)
+  name                = format("%s%s", var.vnet_rule_name_prefix, lookup(var.vnet_rules[count.index], "name", count.index))
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
-  subnet_id           = var.vnet_rules[each.key]["subnet_id"]
+  subnet_id           = var.vnet_rules[count.index]["subnet_id"]
 }
 
 resource "azurerm_postgresql_configuration" "db_configs" {
-  for_each            = toset(keys(var.postgresql_configurations))
+  for_each            = var.postgresql_configurations
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
 
-  name  = element(keys(var.postgresql_configurations), each.key)
-  value = element(values(var.postgresql_configurations), each.key)
+  name  = each.key
+  value = each.value
 }
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_postgresql_server" "server" {
 
 resource "azurerm_postgresql_database" "dbs" {
   for_each            = toset(var.db_names)
-  name                = var.db_names[count.index]
+  name                = var.db_names[each.key]
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
   charset             = var.db_charset
@@ -29,19 +29,19 @@ resource "azurerm_postgresql_database" "dbs" {
 
 resource "azurerm_postgresql_firewall_rule" "firewall_rules" {
   for_each            = toset(var.firewall_rules)
-  name                = format("%s%s", var.firewall_rule_prefix, lookup(var.firewall_rules[count.index], "name", count.index))
+  name                = format("%s%s", var.firewall_rule_prefix, lookup(var.firewall_rules[each.key], "name", each.key))
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
-  start_ip_address    = var.firewall_rules[count.index]["start_ip"]
-  end_ip_address      = var.firewall_rules[count.index]["end_ip"]
+  start_ip_address    = var.firewall_rules[each.key]["start_ip"]
+  end_ip_address      = var.firewall_rules[each.key]["end_ip"]
 }
 
 resource "azurerm_postgresql_virtual_network_rule" "vnet_rules" {
   for_each            = toset(var.vnet_rules)
-  name                = format("%s%s", var.vnet_rule_name_prefix, lookup(var.vnet_rules[count.index], "name", count.index))
+  name                = format("%s%s", var.vnet_rule_name_prefix, lookup(var.vnet_rules[each.key], "name", each.key))
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
-  subnet_id           = var.vnet_rules[count.index]["subnet_id"]
+  subnet_id           = var.vnet_rules[each.key]["subnet_id"]
 }
 
 resource "azurerm_postgresql_configuration" "db_configs" {
@@ -49,7 +49,7 @@ resource "azurerm_postgresql_configuration" "db_configs" {
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
 
-  name  = element(keys(var.postgresql_configurations), count.index)
-  value = element(values(var.postgresql_configurations), count.index)
+  name  = element(keys(var.postgresql_configurations), each.key)
+  value = element(values(var.postgresql_configurations), each.key)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "azurerm_postgresql_server" "server" {
 }
 
 resource "azurerm_postgresql_database" "dbs" {
-  count               = length(var.db_names)
+  for_each            = toset(var.db_names)
   name                = var.db_names[count.index]
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
@@ -28,7 +28,7 @@ resource "azurerm_postgresql_database" "dbs" {
 }
 
 resource "azurerm_postgresql_firewall_rule" "firewall_rules" {
-  count               = length(var.firewall_rules)
+  for_each            = toset(var.firewall_rules)
   name                = format("%s%s", var.firewall_rule_prefix, lookup(var.firewall_rules[count.index], "name", count.index))
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
@@ -37,7 +37,7 @@ resource "azurerm_postgresql_firewall_rule" "firewall_rules" {
 }
 
 resource "azurerm_postgresql_virtual_network_rule" "vnet_rules" {
-  count               = length(var.vnet_rules)
+  for_each            = toset(var.vnet_rules)
   name                = format("%s%s", var.vnet_rule_name_prefix, lookup(var.vnet_rules[count.index], "name", count.index))
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
@@ -45,7 +45,7 @@ resource "azurerm_postgresql_virtual_network_rule" "vnet_rules" {
 }
 
 resource "azurerm_postgresql_configuration" "db_configs" {
-  count               = length(keys(var.postgresql_configurations))
+  for_each            = toset(keys(var.postgresql_configurations))
   resource_group_name = var.resource_group_name
   server_name         = azurerm_postgresql_server.server.name
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,9 @@ output "server_id" {
 
 output "database_ids" {
   description = "The list of all database resource ids"
-  value       = [azurerm_postgresql_database.dbs.*.id]
+  value = toset([
+    for db in azurerm_postgresql_database.dbs : db.id
+  ])
 }
 
 output "firewall_rule_ids" {


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-postgresql .
$ docker run --rm azure-postgresql /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes "Changing order in the list of databases passes to the module causes the module to destroy a valid resource"

Changes proposed in the pull request:
- Make database creation independent from the order of the items in the list of databases.
- for_each has been introduced in 0.12.6. This module already require >= 0.12.20.

