### PR TITLE
Exposing the psqlserver modules auto grow feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ module "postgresql" {
   server_name                   = "example-server"
   sku_name                      = "GP_Gen5_2"
   storage_mb                    = 5120
+  auto_grow_enabled             = false
   backup_retention_days         = 7
   geo_redundant_backup_enabled  = false
   administrator_login           = "login"
@@ -80,6 +81,7 @@ module "postgresql" {
   server_name                   = "example-server"
   sku_name                      = "GP_Gen5_2"
   storage_mb                    = 5120
+  auto_grow_enabled             = false
   backup_retention_days         = 7
   geo_redundant_backup_enabled  = false
   administrator_login           = "login"

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ resource "azurerm_postgresql_server" "server" {
   sku_name = var.sku_name
 
   storage_mb                   = var.storage_mb
+  auto_grow_enabled            = var.auto_grow_enabled
   backup_retention_days        = var.backup_retention_days
   geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -40,6 +40,7 @@ module "postgresql" {
   sku_name    = "GP_Gen5_2"
 
   storage_mb                    = 5120
+  auto_grow_enabled             = true
   backup_retention_days         = 7
   geo_redundant_backup_enabled  = false
   administrator_login           = "azureuser"

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,12 @@ variable "storage_mb" {
   default     = 102400
 }
 
+variable "auto_grow_enabled" {
+  description = "Enable or disable incremental automatic growth of database space."
+  type        = bool
+  default     = false
+}
+
 variable "backup_retention_days" {
   description = "Backup retention days for the server, supported values are between 7 and 35 days."
   type        = number


### PR DESCRIPTION
Changes proposed in the pull request:

It's merely a convenience to have this exposed to user defined resources but most of all, having it exposed simply makes the `storage_profile` attribute consistent by completing it.

All the best,
Jens


