### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_postgresql_server" "server" {
   version                       = var.server_version
   ssl_enforcement_enabled       = var.ssl_enforcement_enabled
   public_network_access_enabled = var.public_network_access_enabled
-
+  auto_grow_enabled             = var.auto_grow_enabled
   tags = var.tags
 }
 


### PR DESCRIPTION
Hey there, the current setup of azure Postgres doesn't have any config to turn on and off the auto_grow_enabled.
The auto_grow_enalbed gives an advantage to the Postgres to increase their volume once it is 90% full.

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-postgresql .
$ docker run --rm azure-postgresql /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:


