### PR TITLE
Added "public_network_access_enabled" to "azurerm_postgresql_server"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,20 @@ module "postgresql" {
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
 
-  server_name                   = "example-server"
-  sku_name                      = "GP_Gen5_2"
-  storage_mb                    = 5120
-  backup_retention_days         = 7
-  geo_redundant_backup_enabled  = false
-  administrator_login           = "login"
-  administrator_password        = "password"
-  server_version                = "9.5"
-  ssl_enforcement_enabled       = true
-  public_network_access_enabled = true
-  db_names                      = ["my_db1", "my_db2"]
-  db_charset                    = "UTF8"
-  db_collation                  = "English_United States.1252"
+  server_name                      = "example-server"
+  sku_name                         = "GP_Gen5_2"
+  storage_mb                       = 5120
+  backup_retention_days            = 7
+  geo_redundant_backup_enabled     = false
+  administrator_login              = "login"
+  administrator_password           = "password"
+  server_version                   = "9.5"
+  ssl_enforcement_enabled          = true
+  ssl_minimal_tls_version_enforced = "TLS1_2"  
+  public_network_access_enabled    = true
+  db_names                         = ["my_db1", "my_db2"]
+  db_charset                       = "UTF8"
+  db_collation                     = "English_United States.1252"
 
   firewall_rule_prefix = "firewall-"
   firewall_rules = [
@@ -77,19 +78,20 @@ module "postgresql" {
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
 
-  server_name                   = "example-server"
-  sku_name                      = "GP_Gen5_2"
-  storage_mb                    = 5120
-  backup_retention_days         = 7
-  geo_redundant_backup_enabled  = false
-  administrator_login           = "login"
-  administrator_password        = "password"
-  server_version                = "9.5"
-  ssl_enforcement_enabled       = true
-  public_network_access_enabled = true
-  db_names                      = ["my_db1", "my_db2"]
-  db_charset                    = "UTF8"
-  db_collation                  = "English_United States.1252"
+  server_name                      = "example-server"
+  sku_name                         = "GP_Gen5_2"
+  storage_mb                       = 5120
+  backup_retention_days            = 7
+  geo_redundant_backup_enabled     = false
+  administrator_login              = "login"
+  administrator_password           = "password"
+  server_version                   = "9.5"
+  ssl_enforcement_enabled          = true
+  ssl_minimal_tls_version_enforced = "TLS1_2"
+  public_network_access_enabled    = true
+  db_names                         = ["my_db1", "my_db2"]
+  db_charset                       = "UTF8"
+  db_collation                     = "English_United States.1252"
 
   firewall_rule_prefix = "firewall-"
   firewall_rules = [

--- a/main.tf
+++ b/main.tf
@@ -9,11 +9,12 @@ resource "azurerm_postgresql_server" "server" {
   backup_retention_days        = var.backup_retention_days
   geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
 
-  administrator_login           = var.administrator_login
-  administrator_login_password  = var.administrator_password
-  version                       = var.server_version
-  ssl_enforcement_enabled       = var.ssl_enforcement_enabled
-  public_network_access_enabled = var.public_network_access_enabled
+  administrator_login              = var.administrator_login
+  administrator_login_password     = var.administrator_password
+  version                          = var.server_version
+  ssl_enforcement_enabled          = var.ssl_enforcement_enabled
+  ssl_minimal_tls_version_enforced = var.ssl_minimal_tls_version_enforced
+  public_network_access_enabled    = var.public_network_access_enabled
 
   tags = var.tags
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -39,17 +39,18 @@ module "postgresql" {
   server_name = "postgresql${random_id.name.hex}"
   sku_name    = "GP_Gen5_2"
 
-  storage_mb                    = 5120
-  backup_retention_days         = 7
-  geo_redundant_backup_enabled  = false
-  administrator_login           = "azureuser"
-  administrator_password        = "Azur3us3r!"
-  server_version                = "9.5"
-  ssl_enforcement_enabled       = true
-  db_names                      = var.db_names
-  db_charset                    = "UTF8"
-  db_collation                  = "English_United States.1252"
-  public_network_access_enabled = true
+  storage_mb                       = 5120
+  backup_retention_days            = 7
+  geo_redundant_backup_enabled     = false
+  administrator_login              = "azureuser"
+  administrator_password           = "Azur3us3r!"
+  server_version                   = "9.5"
+  ssl_enforcement_enabled          = true
+  ssl_minimal_tls_version_enforced = "TLS1_2"
+  db_names                         = var.db_names
+  db_charset                       = "UTF8"
+  db_collation                     = "English_United States.1252"
+  public_network_access_enabled    = true
 
   firewall_rule_prefix = var.fw_rule_prefix
   firewall_rules       = var.fw_rules

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,12 @@ variable "ssl_enforcement_enabled" {
   default     = true
 }
 
+variable "ssl_minimal_tls_version_enforced" {
+  description = "The minimum TLS version to support on the sever. Possible values are TLSEnforcementDisabled, TLS1_0, TLS1_1, and TLS1_2. Defaults to TLSEnforcementDisabled. Must be provided if ssl_enforcement_enabled is set to false."
+  type        = string
+  default     = "TLSEnforcementDisabled"
+}
+
 variable "public_network_access_enabled" {
   description = "Whether or not public network access is allowed for this server. Possible values are Enabled and Disabled."
   type        = bool


### PR DESCRIPTION
### Changes proposed in the pull request:

Added new argument "ssl_minimal_tls_version_enforced" for "azurerm_postgresql_server" resource either build will fail.

Example output of error:
```
`ssl_minimal_tls_version_enforced` must be set to `TLSEnforcementDisabled` if `ssl_enforcement_enabled` is set to `false`

with module.hello-world.module.db.azurerm_postgresql_server.server,
on .terraform/modules/hello-world.db/main.tf line 1, in resource "azurerm_postgresql_server" "server":
1: resource "azurerm_postgresql_server" "server" {
```
