### PR TITLE
Add random string to db server name in examples so we can execute tests concurrently

### DIFF
--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -17,7 +17,7 @@ module "postgresql" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
-  server_name            = "test-server-postgresql"
+  server_name            = "test-server-postgresql-${random_id.rg_name.hex}"
   administrator_login    = "login"
   administrator_password = random_password.password.result
 }

--- a/examples/replica/main.tf
+++ b/examples/replica/main.tf
@@ -17,7 +17,7 @@ module "postgresql" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
-  server_name            = "test-server-primary-postgresql"
+  server_name            = "test-pg-primary-${random_id.rg_name.hex}"
   administrator_login    = "login"
   administrator_password = random_password.password.result
 }
@@ -28,7 +28,7 @@ module "postgresql_replica" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
-  server_name            = "test-server-replica-postgresql"
+  server_name            = "test-pg-replica-${random_id.rg_name.hex}"
   administrator_login    = "login"
   administrator_password = random_password.password.result
 

--- a/test/e2e/terraform_test.go
+++ b/test/e2e/terraform_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"os"
 	"regexp"
 	"testing"
 
@@ -17,9 +18,15 @@ func TestExamples(t *testing.T) {
 
 	for k, v := range testFuncs {
 		t.Run(k, func(t *testing.T) {
-			test_helper.RunE2ETest(t, "../../", k, terraform.Options{
-				Upgrade: true,
-			}, v)
+			retryCfg, err := os.ReadFile("../retryable_errors.hcl.json")
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			opts := terraform.Options{
+				Upgrade:                  true,
+				RetryableTerraformErrors: test_helper.ReadRetryableErrors(retryCfg, t),
+			}
+			test_helper.RunE2ETest(t, "../../", k, opts, v)
 		})
 	}
 }

--- a/test/retryable_errors.hcl.json
+++ b/test/retryable_errors.hcl.json
@@ -1,0 +1,5 @@
+{
+  "retryable_errors": [
+    "Service is temporarily busy"
+  ]
+}


### PR DESCRIPTION
## Describe your changes

It seems like the server's name must be unique in at least subscription level, this pull request added a random string to server's name so we can execute acc tests concurrently.

## Issue number

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

