### PR TITLE
Bump tflint azurerm ruleset version

### DIFF
--- a/.tflint_alt.hcl
+++ b/.tflint_alt.hcl
@@ -6,7 +6,7 @@ SET THIS FILE'S PATH TO $TFLINT_CONFIG ENVVIRONMENT VARIABLE.
 
 plugin "azurerm" {
 enabled = true
-version = "0.21.0"
+version = "0.22.0"
 source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }
 


### PR DESCRIPTION
## Describe your changes

## Issue number

tflint-ruleset-azurerm 0.21.0 contains a [bug ](https://github.com/terraform-linters/tflint-ruleset-azurerm/issues/249), bump to 0.22.0 to fix it.

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

